### PR TITLE
Disable CRC mismatch

### DIFF
--- a/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
+++ b/GeneralsMD/Code/GameEngine/Include/GameLogic/GameLogic.h
@@ -296,6 +296,9 @@ private:
 	UnsignedInt	m_CRC;																			///< Cache of previous CRC value
 	std::map<Int, UnsignedInt> m_cachedCRCs;								///< CRCs we've seen this frame
 	Bool m_shouldValidateCRCs;															///< Should we validate CRCs this frame?
+
+	// show the CRC mismatch message once to inform the player
+	Bool m_hasShownCRCMismatch;
 	//-----------------------------------------------------------------------------------------------
 
 	//Added By Sadullah Nader

--- a/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
+++ b/GeneralsMD/Code/GameEngine/Source/GameLogic/System/GameLogic.cpp
@@ -237,6 +237,7 @@ GameLogic::GameLogic( void )
 	}
 
 	m_shouldValidateCRCs = FALSE;
+	m_hasShownCRCMismatch = FALSE;
 	
 	m_startNewGame = FALSE;
 	//
@@ -2552,7 +2553,7 @@ void GameLogic::processCommandList( CommandList *list )
 		logicMessageDispatcher( msg, NULL );
 	}
 
-	if (m_shouldValidateCRCs && !TheNetwork->sawCRCMismatch())
+	if (m_shouldValidateCRCs && !m_hasShownCRCMismatch)
 	{
 		Bool sawCRCMismatch = FALSE;
 		Int numPlayers = 0;
@@ -2600,7 +2601,11 @@ void GameLogic::processCommandList( CommandList *list )
 					player?player->getPlayerDisplayName().str():L"<NONE>", crcIt->second));
 			}
 #endif // DEBUG_LOGGING
-			TheNetwork->setSawCRCMismatch();
+
+			// just disable the CRC mismatch — it’s generally fine for casual matches with friends
+			// TheNetwork->setSawCRCMismatch();
+			TheInGameUI->message("GUI:CRCMismatch");
+			m_hasShownCRCMismatch = TRUE;
 		}
 	}
 


### PR DESCRIPTION
Disable the CRC mismatch check to support cross-architecture multiplayer (e.g., Apple Silicon vs. Intel).
Addresses a known issue causing desyncs between ARM64 and x64 players in casual matches.